### PR TITLE
Create GitHub Pages-ready React SPA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+.DS_Store
+dist
+dist-ssr
+*.local
+.env
+
+# Editor directories and files
+.vscode/
+.idea/
+*.log
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
-# Hack-Trinidad-Forward-Demo-00
+# Social Post Spinner
+
+A lightweight React app to turn long-form content into platform-specific social posts using a
+Gemini 2.0 Flash prompt. The app is built with Vite + React and is ready to deploy to GitHub Pages as
+an entirely client-side single page application.
+
+## Features
+
+- Paste any long-form source text (blog post, notes, transcripts, etc.)
+- Choose a persona and platform
+- Adjust temperature for creativity vs. control
+- Generates a concise, platform-ready post
+- Stores your Gemini API key locally in the browser only
+
+## Tech Stack
+
+- React + TypeScript
+- Vite
+- Tailwind CSS
+- Google Gemini 2.0 Flash (client-side API)
+
+## Getting Started
+
+### 1. Install dependencies
+
+```bash
+npm install
+```
+
+### 2. Run the dev server
+
+```bash
+npm run dev
+```
+
+Then open the printed URL (typically [http://localhost:5173](http://localhost:5173)) in your browser.
+Paste your Google Gemini API key into the UI before generating posts. The key is saved only in your
+local browser storage so you can refresh without re-entering it.
+
+## Deployment
+
+This project is pre-configured for GitHub Pages. Update the `base` path in `vite.config.ts` if your
+repository name is different. Then run:
+
+```bash
+npm run build
+```
+
+Deploy the contents of the `dist` folder to the `gh-pages` branch (for example with
+[`peaceiris/actions-gh-pages`](https://github.com/peaceiris/actions-gh-pages)). The built app is a
+single page application that runs entirely on the client, so no server configuration is required.
+
+## Environment Variables
+
+Because GitHub Pages cannot securely store environment variables, the app asks for your Gemini API
+key at runtime. If you prefer to bake a key into the build (e.g. for internal demos), add a
+`.env.local` file with `VITE_GEMINI_API_KEY=...` and tweak the app to read from `import.meta.env`
+instead of prompting the user.
+
+---
+
+This project is a starting point—feel free to customize the UI, add more platforms, or enhance the
+prompt engineering.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Social Post Spinner</title>
+  </head>
+  <body class="bg-slate-950">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,2 @@
+{"path":"social-post-spinner"}
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "social-post-spinner",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@google/generative-ai": "^0.21.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@typescript-eslint/eslint-plugin": "^8.18.0",
+    "@typescript-eslint/parser": "^8.18.0",
+    "@vitejs/plugin-react-swc": "^3.7.1",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^9.17.0",
+    "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+    "eslint-plugin-react-refresh": "^0.4.16",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.6.3",
+    "vite": "^6.0.5"
+  }
+}
+

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,7 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0f172a" />
+  <path
+    d="M17 26c0-6 5-11 11-11s11 5 11 11-5 11-11 11S17 32 17 26Zm19 12c0 6 5 11 11 11s11-5 11-11-5-11-11-11-11 5-11 11Z"
+    stroke="#38bdf8"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+import { generatePost } from "./services/geminiService";
+import { Header } from "./components/Header";
+import { SourceInput } from "./components/SourceInput";
+import { PostOutput } from "./components/PostOutput";
+import { ApiKeyInput } from "./components/ApiKeyInput";
+
+const STORAGE_KEY = "social-post-spinner:gemini-api-key";
+
+function App() {
+  const [apiKey, setApiKey] = useState("");
+  const [sourceText, setSourceText] = useState("");
+  const [persona, setPersona] = useState("friendly AI educator");
+  const [platform, setPlatform] = useState("twitter");
+  const [temperature, setTemperature] = useState(0.7);
+  const [generatedPost, setGeneratedPost] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const storedKey = window.localStorage.getItem(STORAGE_KEY);
+    if (storedKey) {
+      setApiKey(storedKey);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (apiKey.trim()) {
+      window.localStorage.setItem(STORAGE_KEY, apiKey.trim());
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [apiKey]);
+
+  const handleGenerate = async () => {
+    if (!apiKey.trim()) {
+      setError("Please enter your Gemini API key.");
+      return;
+    }
+
+    if (!sourceText.trim()) {
+      setError("Please enter some source text.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setGeneratedPost("");
+
+    try {
+      const post = await generatePost({
+        sourceText,
+        persona,
+        platform,
+        temperature,
+        apiKey: apiKey.trim(),
+      });
+      setGeneratedPost(post);
+    } catch (err) {
+      console.error(err);
+      setError("Failed to generate post. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-50">
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <Header />
+
+        <ApiKeyInput apiKey={apiKey} onApiKeyChange={setApiKey} />
+
+        {error && (
+          <div className="mb-4 rounded-lg bg-red-500/10 border border-red-500/50 px-4 py-3 text-sm text-red-100">
+            {error}
+          </div>
+        )}
+
+        <div className="grid gap-6 md:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+          <SourceInput
+            sourceText={sourceText}
+            onSourceTextChange={setSourceText}
+            persona={persona}
+            onPersonaChange={setPersona}
+            platform={platform}
+            onPlatformChange={setPlatform}
+            temperature={temperature}
+            onTemperatureChange={setTemperature}
+            onGenerate={handleGenerate}
+            loading={loading}
+            canGenerate={Boolean(apiKey.trim())}
+          />
+
+          <PostOutput generatedPost={generatedPost} loading={loading} />
+        </div>
+
+        <footer className="mt-8 pt-6 border-t border-slate-800/60 text-xs text-slate-500 flex flex-wrap gap-2 items-center justify-between">
+          <span>
+            Built with <span className="text-sky-400">Gemini 2.0 Flash</span> & Vite + React
+          </span>
+          <span className="text-slate-600">
+            Tip: Start with a short article, blog post, or outline.
+          </span>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+export default App;
+

--- a/src/components/ApiKeyInput.tsx
+++ b/src/components/ApiKeyInput.tsx
@@ -1,0 +1,33 @@
+interface ApiKeyInputProps {
+  apiKey: string;
+  onApiKeyChange: (value: string) => void;
+}
+
+export function ApiKeyInput({ apiKey, onApiKeyChange }: ApiKeyInputProps) {
+  return (
+    <section className="mb-6 rounded-2xl bg-slate-900/70 border border-slate-800/90 p-4">
+      <div className="flex flex-col gap-2 text-[11px] text-slate-200">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-wide">
+              Gemini API key
+            </h2>
+            <p className="mt-1 text-[11px] text-slate-500 max-w-2xl">
+              The app runs entirely in your browser. Paste a Google Gemini API key with access to
+              the <span className="text-sky-400">Gemini 2.0 Flash</span> model. Your key is stored
+              locally in this browser only.
+            </p>
+          </div>
+        </div>
+        <input
+          type="password"
+          value={apiKey}
+          onChange={(event) => onApiKeyChange(event.target.value)}
+          placeholder="Paste your Google Gemini API key"
+          className="rounded-lg bg-slate-950/70 border border-slate-800/90 px-3 py-2 text-[11px] text-slate-100 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-sky-500/70 focus:border-sky-500/70"
+        />
+      </div>
+    </section>
+  );
+}
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,22 @@
+export function Header() {
+  return (
+    <header className="mb-8">
+      <div className="flex items-center gap-3 mb-2">
+        <div className="w-9 h-9 rounded-xl bg-sky-500/10 border border-sky-500/40 flex items-center justify-center">
+          <span className="text-sky-400 text-lg">∞</span>
+        </div>
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight text-slate-50">Social Post Spinner</h1>
+          <p className="text-xs text-slate-400">
+            Paste long-form content → get platform-ready posts in one click.
+          </p>
+        </div>
+      </div>
+      <p className="text-xs text-slate-500 max-w-xl">
+        This demo runs entirely in your browser using <span className="text-sky-400">Gemini 2.0 Flash</span>,
+        and doesn't send your content to any server other than Google's API.
+      </p>
+    </header>
+  );
+}
+

--- a/src/components/PostOutput.tsx
+++ b/src/components/PostOutput.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { ClipboardIcon } from "./icons/ClipboardIcon";
+import { CheckIcon } from "./icons/CheckIcon";
+import { SparklesIcon } from "./icons/SparklesIcon";
+
+interface PostOutputProps {
+  generatedPost: string;
+  loading: boolean;
+}
+
+export function PostOutput({ generatedPost, loading }: PostOutputProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!generatedPost) {
+      setCopied(false);
+    }
+  }, [generatedPost]);
+
+  const handleCopy = async () => {
+    if (!generatedPost) return;
+
+    try {
+      await navigator.clipboard.writeText(generatedPost);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy text:", err);
+    }
+  };
+
+  return (
+    <section className="rounded-2xl bg-slate-900/60 border border-slate-800/80 p-4 flex flex-col min-h-[320px]">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <div className="w-6 h-6 rounded-lg bg-sky-500/10 border border-sky-500/40 flex items-center justify-center">
+            <SparklesIcon className="w-3 h-3 text-sky-400" />
+          </div>
+          <h2 className="text-sm font-medium tracking-tight text-slate-50">Generated Post</h2>
+        </div>
+        <button
+          onClick={handleCopy}
+          disabled={!generatedPost}
+          className="inline-flex items-center gap-1 rounded-md border border-slate-700/80 bg-slate-900/60 px-2.5 py-1 text-[11px] font-medium text-slate-200 shadow-sm disabled:opacity-40 disabled:cursor-not-allowed hover:border-slate-600 hover:bg-slate-900"
+        >
+          {copied ? (
+            <>
+              <CheckIcon className="w-3 h-3" />
+              Copied
+            </>
+          ) : (
+            <>
+              <ClipboardIcon className="w-3 h-3" />
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+
+      <div className="relative flex-1">
+        <div className="absolute inset-0 rounded-xl bg-slate-950/50 border border-slate-800/80 px-3 py-2 text-xs font-mono text-slate-100/90 overflow-auto">
+          {loading ? (
+            <div className="flex items-center gap-2 text-slate-500 text-[11px]">
+              <span className="inline-flex h-1.5 w-1.5 rounded-full bg-sky-400 animate-pulse" />
+              Generating post...
+            </div>
+          ) : generatedPost ? (
+            <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">
+              {generatedPost}
+            </pre>
+          ) : (
+            <p className="text-[11px] text-slate-600">
+              Your post will appear here. Try pasting a short article, choosing a persona, and clicking
+              <span className="text-sky-400 font-medium"> Spin Post</span>.
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/components/SourceInput.tsx
+++ b/src/components/SourceInput.tsx
@@ -1,0 +1,111 @@
+import { SparklesIcon } from "./icons/SparklesIcon";
+
+interface SourceInputProps {
+  sourceText: string;
+  onSourceTextChange: (value: string) => void;
+  persona: string;
+  onPersonaChange: (value: string) => void;
+  platform: string;
+  onPlatformChange: (value: string) => void;
+  temperature: number;
+  onTemperatureChange: (value: number) => void;
+  onGenerate: () => void;
+  loading: boolean;
+  canGenerate: boolean;
+}
+
+export function SourceInput({
+  sourceText,
+  onSourceTextChange,
+  persona,
+  onPersonaChange,
+  platform,
+  onPlatformChange,
+  temperature,
+  onTemperatureChange,
+  onGenerate,
+  loading,
+  canGenerate,
+}: SourceInputProps) {
+  return (
+    <section className="rounded-2xl bg-slate-900/70 border border-slate-800/90 p-4 flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <label className="block text-xs font-medium text-slate-300 mb-1">Source content</label>
+          <p className="text-[11px] text-slate-500 max-w-md">
+            Paste a blog excerpt, notes, or any long-form text. The AI will distill it into a
+            platform-specific post.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onGenerate}
+          disabled={loading || !canGenerate}
+          className="inline-flex items-center gap-1 rounded-full bg-sky-500 px-3 py-1.5 text-[11px] font-semibold text-slate-950 shadow-lg shadow-sky-500/30 hover:bg-sky-400 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <SparklesIcon className="w-3.5 h-3.5" />
+          {loading ? "Spinning..." : "Spin Post"}
+        </button>
+      </div>
+
+      <textarea
+        value={sourceText}
+        onChange={(event) => onSourceTextChange(event.target.value)}
+        className="w-full min-h-[180px] rounded-xl bg-slate-950/70 border border-slate-800/90 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-sky-500/70 focus:border-sky-500/70 font-mono"
+        placeholder="Paste your long-form content here..."
+      />
+
+      <div className="grid gap-3 md:grid-cols-3 text-[11px] text-slate-200">
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] font-medium text-slate-300">Persona</label>
+          <input
+            type="text"
+            value={persona}
+            onChange={(event) => onPersonaChange(event.target.value)}
+            className="rounded-lg bg-slate-950/70 border border-slate-800/90 px-2 py-1.5 text-[11px] text-slate-100 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-sky-500/70 focus:border-sky-500/70"
+            placeholder="e.g. friendly AI educator"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] font-medium text-slate-300">Platform</label>
+          <select
+            value={platform}
+            onChange={(event) => onPlatformChange(event.target.value)}
+            className="rounded-lg bg-slate-950/70 border border-slate-800/90 px-2 py-1.5 text-[11px] text-slate-100 focus:outline-none focus:ring-1 focus:ring-sky-500/70 focus:border-sky-500/70"
+          >
+            <option value="twitter">Twitter / X</option>
+            <option value="linkedin">LinkedIn</option>
+            <option value="instagram">Instagram caption</option>
+            <option value="threads">Threads</option>
+            <option value="facebook">Facebook post</option>
+            <option value="youtube">YouTube description</option>
+            <option value="tiktok">TikTok caption</option>
+            <option value="email">Email subject + hook</option>
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] font-medium text-slate-300 flex items-center justify-between">
+            Creativity
+            <span className="text-[10px] text-slate-500">{temperature.toFixed(2)}</span>
+          </label>
+          <input
+            type="range"
+            min={0.1}
+            max={1}
+            step={0.05}
+            value={temperature}
+            onChange={(event) => onTemperatureChange(parseFloat(event.target.value))}
+            className="w-full accent-sky-400"
+          />
+          <div className="flex justify-between text-[10px] text-slate-500">
+            <span>More exact</span>
+            <span>More creative</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/components/icons/CheckIcon.tsx
+++ b/src/components/icons/CheckIcon.tsx
@@ -1,0 +1,21 @@
+interface CheckIconProps {
+  className?: string;
+}
+
+export function CheckIcon({ className = "" }: CheckIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+

--- a/src/components/icons/ClipboardIcon.tsx
+++ b/src/components/icons/ClipboardIcon.tsx
@@ -1,0 +1,22 @@
+interface ClipboardIconProps {
+  className?: string;
+}
+
+export function ClipboardIcon({ className = "" }: ClipboardIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <rect width="8" height="4" x="8" y="2" rx="1" ry="1" />
+      <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+    </svg>
+  );
+}
+

--- a/src/components/icons/SparklesIcon.tsx
+++ b/src/components/icons/SparklesIcon.tsx
@@ -1,0 +1,25 @@
+interface SparklesIconProps {
+  className?: string;
+}
+
+export function SparklesIcon({ className = "" }: SparklesIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M12 3 9 9 3 12l6 3 3 6 3-6 6-3-6-3-3-6Z" />
+      <path d="M5 3v4" />
+      <path d="M19 17v4" />
+      <path d="M3 5h4" />
+      <path d="M17 19h4" />
+    </svg>
+  );
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  font-family: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+}
+
+pre {
+  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -1,0 +1,71 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+interface GeneratePostParams {
+  sourceText: string;
+  persona: string;
+  platform: string;
+  temperature: number;
+  apiKey: string;
+}
+
+const PROMPT_PREFIX = `You are an expert social media copywriter.
+
+Task: Rewrite the source content into "one" concise, engaging post for the specified platform.
+
+Requirements:
+
+* Use the specified persona and platform conventions.
+* Focus on one key idea or hook from the source.
+* Avoid hashtags unless they are crucial.
+* Prefer plain language and short sentences.
+* No emojis unless the platform usually embraces them.
+* No preambles about yourself or what you are doing.
+* Do not include explanations or analysis.
+* Just output the final post.
+`;
+
+export async function generatePost({
+  sourceText,
+  persona,
+  platform,
+  temperature,
+  apiKey,
+}: GeneratePostParams): Promise<string> {
+  if (!apiKey) {
+    throw new Error("Missing Gemini API key");
+  }
+
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({ model: "gemini-2.0-flash" });
+
+  const prompt = `${PROMPT_PREFIX}
+
+Persona: ${persona}
+Platform: ${platform}
+
+Source content:
+"""
+${sourceText}
+"""
+
+Write the final post now.`;
+
+  const result = await model.generateContent({
+    contents: [
+      {
+        role: "user",
+        parts: [{ text: prompt }],
+      },
+    ],
+    generationConfig: {
+      temperature,
+      maxOutputTokens: 300,
+    },
+  });
+
+  const response = result.response;
+  const text = response.text();
+
+  return text.trim();
+}
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}
+

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  base: "/social-post-spinner/",
+});
+


### PR DESCRIPTION
## Summary
- scaffold a Vite + React single-page app with Tailwind styling and Gemini post generation workflow
- add client-side Gemini API key input that stores locally so the build works on GitHub Pages
- configure Vite for GitHub Pages deployment and document usage and deployment steps

## Testing
- npm install *(fails: 403 Forbidden fetching @google/generative-ai from npm registry)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179c4206f0832cbb55a7519f1b7aef)