### PR TITLE
Fix GitHub Pages enablement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- ensure the configure-pages step explicitly enables the GitHub Pages site so deployment can succeed

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a415fb04832cbbe6c5692bdc1ee9)